### PR TITLE
WIP: Make scripts work in Linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    proteus-kits (0.0.3)
+    proteus-kits (0.0.4.1)
       thor
 
 GEM

--- a/lib/proteus/kit.rb
+++ b/lib/proteus/kit.rb
@@ -25,19 +25,19 @@ module Proteus
     desc "setup", "Sets up the project"
     def setup
       puts "Setting up your project"
-      system ". bin/setup"
+      system "bin/setup"
     end
 
     desc "server", "Runs the server"
     def server
       puts "Starting the server"
-      system ". bin/server"
+      system "bin/server"
     end
 
     desc "deploy", "Deploys the site to Github"
     def deploy
       puts "Deploying the site to Github"
-      system ". bin/deploy"
+      system "bin/deploy"
     end
 
     desc "version", "Show Proteus version"


### PR DESCRIPTION
Fixes #4 

Fixed the chmod setting on the bin scripts in each kit. This lets us just run "bin/setup" and avoid the dot syntax. This should fix the problem in #4.
