### PR TITLE
Destroy the existing .git folder and make a new one 

### DIFF
--- a/lib/proteus/kit.rb
+++ b/lib/proteus/kit.rb
@@ -16,13 +16,13 @@ module Proteus
 
       if system "git ls-remote #{url(kit_name)} #{repo_name} > /dev/null 2>&1"
         puts "Starting a new proteus-#{kit_name} project in #{repo_name}"
-        system "git clone #{url(kit_name)}#{' ' + repo_name} && "\
-          "cd #{repo_name} && "\
-          "rm -rf .git && "\
-          "git init && "\
-          "git add . && "\
-          "git commit -am 'New proteus-#{kit_name} project' && "\
-          "cd -"
+        system "git clone #{url(kit_name)}#{' ' + repo_name} && \
+          cd #{repo_name} && \
+          rm -rf .git && \
+          git init && \
+          git add . && \
+          git commit -am 'New proteus-#{kit_name} project' && \
+          cd - "
       else
         puts "A thoughtbot repo doesn't exist with that name"
       end

--- a/lib/proteus/kit.rb
+++ b/lib/proteus/kit.rb
@@ -17,8 +17,8 @@ module Proteus
       if system "git ls-remote #{url(kit_name)} #{repo_name} > /dev/null 2>&1"
         puts "Starting a new proteus-#{kit_name} project in #{repo_name}"
         system %{
-          git clone #{url(kit_name)} #{repo_name} &&
-          cd #{repo_name} &&
+          git clone "#{url(kit_name)}" "#{repo_name}" &&
+          cd "#{repo_name}" &&
           rm -rf .git &&
           git init &&
           git add . &&

--- a/lib/proteus/kit.rb
+++ b/lib/proteus/kit.rb
@@ -16,7 +16,9 @@ module Proteus
 
       if system "git ls-remote #{url(kit_name)} #{repo_name} > /dev/null 2>&1"
         puts "Starting a new proteus-#{kit_name} project in #{repo_name}"
-        system "git clone #{url(kit_name)}#{' ' + repo_name}"
+        system "git clone #{url(kit_name)}#{' ' + repo_name} && "\
+          "rm -rf #{repo_name}/.git && "\
+          "git init #{repo_name}"
       else
         puts "A thoughtbot repo doesn't exist with that name"
       end

--- a/lib/proteus/kit.rb
+++ b/lib/proteus/kit.rb
@@ -17,8 +17,12 @@ module Proteus
       if system "git ls-remote #{url(kit_name)} #{repo_name} > /dev/null 2>&1"
         puts "Starting a new proteus-#{kit_name} project in #{repo_name}"
         system "git clone #{url(kit_name)}#{' ' + repo_name} && "\
-          "rm -rf #{repo_name}/.git && "\
-          "git init #{repo_name}"
+          "cd #{repo_name} && "\
+          "rm -rf .git && "\
+          "git init && "\
+          "git add . && "\
+          "git commit -am 'New proteus-#{kit_name} project' && "\
+          "cd -"
       else
         puts "A thoughtbot repo doesn't exist with that name"
       end

--- a/lib/proteus/kit.rb
+++ b/lib/proteus/kit.rb
@@ -16,13 +16,15 @@ module Proteus
 
       if system "git ls-remote #{url(kit_name)} #{repo_name} > /dev/null 2>&1"
         puts "Starting a new proteus-#{kit_name} project in #{repo_name}"
-        system "git clone #{url(kit_name)}#{' ' + repo_name} && \
-          cd #{repo_name} && \
-          rm -rf .git && \
-          git init && \
-          git add . && \
-          git commit -am 'New proteus-#{kit_name} project' && \
-          cd - "
+        system %{
+          git clone #{url(kit_name)} #{repo_name} &&
+          cd #{repo_name} &&
+          rm -rf .git &&
+          git init &&
+          git add . &&
+          git commit -am 'New proteus-#{kit_name} project' &&
+          cd -
+        }
       else
         puts "A thoughtbot repo doesn't exist with that name"
       end


### PR DESCRIPTION
So users will have a clean history after making a new `proteus` project.

Note that if/when this is merged, the following files will need to be updated:
https://github.com/thoughtbot/proteus-middleman/blob/master/bin/setup
https://github.com/thoughtbot/proteus-jekyll/blob/master/bin/setup
https://github.com/thoughtbot/proteus-gulp/blob/master/bin/setup

Specifically, the code below the following comments:
`# Squash all commits to get a clean slate`
`# Remove Git remote if it's still the proteus-______ repo`

Which is a good thing! Because we don't want duplicated code (across repos, especially!)