### PR TITLE
Fix proteus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 pkg
 tmp
+spec/dummy

--- a/lib/proteus/kit.rb
+++ b/lib/proteus/kit.rb
@@ -14,7 +14,7 @@ module Proteus
     def new(kit_name, repo_name = nil)
       repo_name ||= kit_name
 
-      if system "git ls-remote #{url(kit_name)} #{repo_name} > /dev/null 2>&1"
+      if system "git ls-remote #{url(kit_name)} > /dev/null 2>&1"
         puts "Starting a new proteus-#{kit_name} project in #{repo_name}"
         system %{
           git clone "#{url(kit_name)}" "#{repo_name}" &&

--- a/lib/proteus/kit.rb
+++ b/lib/proteus/kit.rb
@@ -50,7 +50,7 @@ module Proteus
 
     desc "version", "Show Proteus version"
     def version
-        say "Proteus #{Proteus::VERSION}"
+      say "Proteus #{Proteus::VERSION}"
     end
   end
 end

--- a/proteus-kits.gemspec
+++ b/proteus-kits.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 2.6"
+  spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "thor"
 end

--- a/spec/proteus_spec.rb
+++ b/spec/proteus_spec.rb
@@ -11,6 +11,6 @@ describe Proteus do
   end
 
   it "returns a friendly message if the repo doesn't exist" do
-    expect(@proteus.new('invalid')).to eq("A thoughtbot repo doesn't exist with that name")
+    expect { @proteus.new('invalid') }.to output("A thoughtbot repo doesn't exist with that name\n").to_stdout
   end
 end

--- a/spec/proteus_spec.rb
+++ b/spec/proteus_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 
 describe Proteus do
-  before do
+  before(:all) do
+    remove_dummy_repo
     @proteus = Proteus::Kit.new
   end
 
@@ -10,7 +11,21 @@ describe Proteus do
     expect(url).to eq("git@github.com:thoughtbot/proteus-test.git")
   end
 
+  it "finds and download a kit" do
+    kit_name = 'middleman'
+    repo_name = 'spec/dummy'
+
+    quietly do
+      expect { @proteus.new(kit_name, repo_name) }.to output("Starting a new proteus-#{kit_name} project in #{repo_name}\n").to_stdout
+    end
+  end
+
   it "returns a friendly message if the repo doesn't exist" do
     expect { @proteus.new('invalid') }.to output("A thoughtbot repo doesn't exist with that name\n").to_stdout
   end
+
+  private
+    def remove_dummy_repo
+      FileUtils.rm_rf(Dir["./spec/dummy"])
+    end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,25 @@
 $LOAD_PATH << File.join('../lib')
 
 require 'proteus'
+
+def quietly
+  streams = STDOUT, STDERR
+  on_hold = streams.collect { |stream| stream.dup }
+  streams.each do |stream|
+    stream.reopen(null_stream)
+    stream.sync = true
+  end
+  yield
+  ensure
+    streams.each_with_index do |stream, i|
+      stream.reopen(on_hold[i])
+    end
+end
+
+def null_stream
+  if RUBY_PLATFORM =~ /mswin/
+    'NUL:'
+  else
+    '/dev/null'
+  end
+end


### PR DESCRIPTION
* Fix system call of `git ls-remote`.
* Update RSpec to 3.3 version to use match `output`.
* Add tests for an existing kit
* Tests are green (were broken). Set up Travis CI maybe?

[Closes #9]