### PR TITLE
#9 fixed: public url used for cloning

### DIFF
--- a/lib/proteus/kit.rb
+++ b/lib/proteus/kit.rb
@@ -7,7 +7,7 @@ module Proteus
 
     desc "url", "gets the git url"
     def url(kit)
-      "git@github.com:thoughtbot/proteus-#{kit}.git"
+      "https://github.com/thoughtbot/proteus-#{kit}.git"
     end
 
     desc "new", "runs the command to clone a particular kit"


### PR DESCRIPTION
avoid access rights check for the `git clone` command by using the public url