### PR TITLE
Use an explicit list of repos

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2014–2015 [thoughtbot, inc.](http://thoughtbot.com)
+Copyright © 2014–2016 [thoughtbot, inc.](http://thoughtbot.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and includes our favorite front-end development tools.
 
 * [Middleman](http://github.com/thoughtbot/proteus-middleman)
 * [Jekyll](http://github.com/thoughtbot/proteus-jekyll)
-* [Gulp](http://github.com/thoughtbot/proteus-gulp)
+* Have a request for another kit? Open an issue to let us know.
 
 ## Installation
 
@@ -69,4 +69,4 @@ Proteus is maintained and funded by [thoughtbot, inc](http://thoughtbot.com). Th
 
 ## License
 
-Copyright © 2014–2015 [thoughtbot, inc](http://thoughtbot.com). Proteus is free software, and may be redistributed under the terms specified in the [license](LICENSE.md).
+Copyright © 2014–2016 [thoughtbot, inc](http://thoughtbot.com). Proteus is free software, and may be redistributed under the terms specified in the [license](LICENSE.md).

--- a/lib/proteus.rb
+++ b/lib/proteus.rb
@@ -1,2 +1,3 @@
 require "proteus/version"
+require "proteus/repos"
 require "proteus/kit"

--- a/lib/proteus/repos.rb
+++ b/lib/proteus/repos.rb
@@ -1,0 +1,13 @@
+module Proteus
+  REPOS = {
+    middleman: {
+      name: "Middleman Starter",
+      url: "https://github.com/thoughtbot/proteus-middleman.git"
+    },
+
+    jekyll: {
+      name: "Jekyll Starter",
+      url: "https://github.com/thoughtbot/proteus-jekyll.git"
+    }
+  }
+end

--- a/lib/proteus/version.rb
+++ b/lib/proteus/version.rb
@@ -1,3 +1,3 @@
 module Proteus
-  VERSION = "0.1"
+  VERSION = "0.4"
 end

--- a/proteus-kits.gemspec
+++ b/proteus-kits.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"
 
-  spec.add_dependency "thor"
+  spec.add_dependency "thor", "~> 0.19"
 end

--- a/spec/proteus_spec.rb
+++ b/spec/proteus_spec.rb
@@ -1,31 +1,44 @@
 require "spec_helper"
 
 describe Proteus do
-  before(:all) do
+  before do
     remove_dummy_repo
     @proteus = Proteus::Kit.new
+    @repos = Proteus::REPOS
   end
 
-  it "completes the url" do
-    url = @proteus.url("test")
-    expect(url).to eq("git@github.com:thoughtbot/proteus-test.git")
+  it "has a list of repos" do
+    expect(@repos).not_to be_nil
   end
 
-  it "finds and download a kit" do
-    kit_name = 'middleman'
-    repo_name = 'spec/dummy'
-
-    quietly do
-      expect { @proteus.new(kit_name, repo_name) }.to output("Starting a new proteus-#{kit_name} project in #{repo_name}\n").to_stdout
-    end
+  it "gets repos in the list" do
+    expect(@repos.size).to be > 0
   end
 
-  it "returns a friendly message if the repo doesn't exist" do
-    expect { @proteus.new('invalid') }.to output("A thoughtbot repo doesn't exist with that name\n").to_stdout
+  it "gets the kit name" do
+    expect(@proteus.name("jekyll")).to eq("Jekyll Starter")
   end
 
-  private
-    def remove_dummy_repo
-      FileUtils.rm_rf(Dir["./spec/dummy"])
-    end
+  it "gets the Git url" do
+    url = "https://github.com/thoughtbot/proteus-middleman.git"
+    expect(@proteus.url("middleman")).to eq(url)
+  end
+
+  it "displays a list of repos" do
+    expect { @proteus.list }.to output().to_stdout
+  end
+
+  it "displays a friendly message if the kit isn't in the list" do
+    message = "Kit not found. Run `proteus list` to see available kits.\n"
+    expect { @proteus.new("invalid") }.to output(message).to_stdout
+  end
+
+  it "displays the current version" do
+    version = Proteus::VERSION
+    expect { @proteus.version }.to output("Proteus #{version}\n").to_stdout
+  end
+
+  def remove_dummy_repo
+    FileUtils.rm_rf(Dir["./spec/dummy"])
+  end
 end


### PR DESCRIPTION
This PR adds a list of repos, which allows us to display a list of available kits. This means kits don't have to conform to a predefined naming scheme, or even be hosted under thoughtbot's Github account. It also adds test coverage for some existing commands.
